### PR TITLE
Add complex query variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The dataset consists of environmental sensor telemetry data collected from multi
   2.  Reading the highest measured temperature over all devices.
   3.  Calculating the worst the worst air quality by aggregating “co”, “lpg” and “smoke”
       per device. Sum of the % for each device.
+- Additional query variants in each analysis notebook show how to accomplish these tasks with more complex SQL and Flux expressions.
 - Measure and compare query performance, data ingestion speed, and storage efficiency.
 - Summarize findings and provide recommendations for similar IoT analytics scenarios.
 

--- a/influxdb_analysis.ipynb
+++ b/influxdb_analysis.ipynb
@@ -130,19 +130,19 @@
     "mean_temp = data\n",
     "  |> filter(fn: (r) => r[\"_field\"] == \"temp\")\n",
     "  |> aggregateWindow(every: 1h, fn: mean, createEmpty: false)\n",
-    "  |> drop(columns: [\"_measurement\", \"_field\"]) // Nicht mehr benötigte Spalten entfernen\n",
+    "  |> drop(columns: [\"_measurement\", \"_field\"]) // Nicht mehr ben\u00f6tigte Spalten entfernen\n",
     "\n",
     "\n",
     "max_humidity = data\n",
     "  |> filter(fn: (r) => r[\"_field\"] == \"humidity\")\n",
     "  |> aggregateWindow(every: 1h, fn: max, createEmpty: false)\n",
-    "  |> drop(columns: [\"_measurement\", \"_field\"]) // Nicht mehr benötigte Spalten entfernen\n",
+    "  |> drop(columns: [\"_measurement\", \"_field\"]) // Nicht mehr ben\u00f6tigte Spalten entfernen\n",
     "\n",
     "\n",
-    "// Ergebnisse zusammenführen und pivotieren\n",
+    "// Ergebnisse zusammenf\u00fchren und pivotieren\n",
     "join(tables: {temp: mean_temp, humidity: max_humidity}, on: [\"_time\", \"_stop\", \"_start\", \"device\"])\n",
-    "  |> rename(columns: { _value_temp: \"mean_temp\", _value_humidity: \"max_humidity\"}) // Spalten umbenennen für Klarheit\n",
-    "  |> sort(columns: [\"_time\", \"device\"]) // Optional: Sortieren für bessere Lesbarkeit\n",
+    "  |> rename(columns: { _value_temp: \"mean_temp\", _value_humidity: \"max_humidity\"}) // Spalten umbenennen f\u00fcr Klarheit\n",
+    "  |> sort(columns: [\"_time\", \"device\"]) // Optional: Sortieren f\u00fcr bessere Lesbarkeit\n",
     "\"\"\""
    ]
   },
@@ -196,6 +196,53 @@
     "    |> map(fn: (r) => ({ r with temp_humidity_ratio: r.temp / r.humidity }))\n",
     "    |> mean(column: \"temp_humidity_ratio\")\n",
     "    |> yield(name: \"avg_temp_humidity_ratio\")\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "519e994b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "average_humidity_per_device_query_complex = \"\"\"\n",
+    "from(bucket: \"iot_telemetry_data\")\n",
+    "  |> range(start: 0)\n",
+    "  |> filter(fn: (r) =>\n",
+    "      r._measurement == \"iot_telemetry\" and\n",
+    "      r._field == \"humidity\"\n",
+    "  )\n",
+    "  |> group(columns: [\"device\"])\n",
+    "  |> reduce(fn: (r, acc) => ({\n",
+    "      device: r.device,\n",
+    "      sum: acc.sum + r._value,\n",
+    "      count: acc.count + 1\n",
+    "  }), identity: {sum: 0.0, count: 0})\n",
+    "  |> map(fn: (r) => ({ r with avg_humidity: r.sum / float(v: r.count) }))\n",
+    "  |> keep(columns: [\"device\", \"avg_humidity\"])\n",
+    "  |> sort(columns: [\"device\"])\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1eca9d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "highest_temp_query_complex = \"\"\"\n",
+    "from(bucket: \"iot_telemetry_data\")\n",
+    "  |> range(start: 0)\n",
+    "  |> filter(fn: (r) =>\n",
+    "      r._measurement == \"iot_telemetry\" and\n",
+    "      r._field == \"temp\"\n",
+    "  )\n",
+    "  |> aggregateWindow(every: 1h, fn: max, createEmpty: false)\n",
+    "  |> group()\n",
+    "  |> max(column: \"_value\")\n",
+    "  |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n",
     "\"\"\""
    ]
   },
@@ -443,6 +490,44 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "178faabc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    client = InfluxDBClient(url=url, token=token, org=org)\n",
+    "    query_api = QueryApi(influxdb_client=client)\n",
+    "    start_time = time.time()\n",
+    "    result = query_api.query_data_frame(average_humidity_per_device_query_complex)\n",
+    "    end_time = time.time()\n",
+    "    print(f\"Query took {end_time - start_time} seconds.\")\n",
+    "    query_times['Average Humidity Complex'] = (end_time - start_time)\n",
+    "except InfluxDBError as e:\n",
+    "    print('Error: ', e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c532874",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    client = InfluxDBClient(url=url, token=token, org=org)\n",
+    "    query_api = QueryApi(influxdb_client=client)\n",
+    "    start_time = time.time()\n",
+    "    result = query_api.query_data_frame(highest_temp_query_complex)\n",
+    "    end_time = time.time()\n",
+    "    print(f\"Query took {end_time - start_time} seconds.\")\n",
+    "    query_times['Highest Temp Complex'] = (end_time - start_time)\n",
+    "except InfluxDBError as e:\n",
+    "    print('Error: ', e)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "dceb77ed",
    "metadata": {},
@@ -496,7 +581,7 @@
     "filename = \"performance.txt\"\n",
     "\n",
     "\n",
-    "# 'a' öffnet die Datei im Append-Modus (erstellt sie, falls sie nicht existiert)\n",
+    "# 'a' \u00f6ffnet die Datei im Append-Modus (erstellt sie, falls sie nicht existiert)\n",
     "with open(filename, \"a\", encoding=\"utf-8\") as f:\n",
     "    f.write(performance + \"\\n\")\n",
     "\n",

--- a/oracle_analysis.ipynb
+++ b/oracle_analysis.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#-- 1) Durchschnittliche Luftfeuchtigkeit (humidity) pro Gerät\n",
+    "#-- 1) Durchschnittliche Luftfeuchtigkeit (humidity) pro Ger\u00e4t\n",
     "average_humidity_per_device_query = \"\"\"SELECT\n",
     "  DEVICE,\n",
     "  AVG(HUMIDITY) AS avg_humidity\n",
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# -- 2) Höchste gemessene Temperatur über alle Geräte\n",
+    "# -- 2) H\u00f6chste gemessene Temperatur \u00fcber alle Ger\u00e4te\n",
     "highest_temp_query = \"\"\"SELECT\n",
     "  MAX(temp) AS max_temperature\n",
     "FROM IOT_TELEMETRY_DATA\n",
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# -- 3) “Worst air quality” per Gerät als Summe der drei Schadstoffe\n",
+    "# -- 3) \u201cWorst air quality\u201d per Ger\u00e4t als Summe der drei Schadstoffe\n",
     "worst_air_quality_per_device_query = \"\"\"SELECT\n",
     "  device,\n",
     "  SUM(co + lpg + smoke) AS air_quality_score\n",
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Query: Tages-AVG pro Gerät + Abweichung in %\n",
+    "# Query: Tages-AVG pro Ger\u00e4t + Abweichung in %\n",
     "diff_query = \"\"\"\n",
     "SELECT\n",
     "  ts,\n",
@@ -125,7 +125,7 @@
     "hourly_temp_hum_query = \"\"\"\n",
     "SELECT\n",
     "    TRUNC(TS, 'HH') AS HOUR_WINDOW, -- Zeitstempel-Spalte 'TS' auf Stunde runden\n",
-    "    DEVICE, -- Geräte-Spalte 'DEVICE'\n",
+    "    DEVICE, -- Ger\u00e4te-Spalte 'DEVICE'\n",
     "    AVG(TEMP) AS MEAN_TEMP, -- Durchschnitt der Temperatur-Spalte 'TEMP'\n",
     "    MAX(HUMIDITY) AS MAX_HUMIDITY -- Maximum der Luftfeuchtigkeit-Spalte 'HUMIDITY'\n",
     "FROM\n",
@@ -133,7 +133,7 @@
     "WHERE\n",
     "    TS >= TO_TIMESTAMP('2002-04-07 00:00:00', 'YYYY-MM-DD HH24:MI:SS') -- Startzeit (anpassen!)\n",
     "    AND TS < CURRENT_TIMESTAMP -- Endzeit (jetzt)\n",
-    "    AND DEVICE IN ('00:0f:00:70:91:0a', '1c:bf:ce:15:ec:4d', 'eb:b8:27:bf:9d:51') -- Geräte-IDs\n",
+    "    AND DEVICE IN ('00:0f:00:70:91:0a', '1c:bf:ce:15:ec:4d', 'eb:b8:27:bf:9d:51') -- Ger\u00e4te-IDs\n",
     "GROUP BY\n",
     "    TRUNC(TS, 'HH'),\n",
     "    DEVICE\n",
@@ -169,7 +169,7 @@
     "    DEVICE,\n",
     "    TEMP,\n",
     "    CASE\n",
-    "        WHEN PREV_TS IS NULL OR TS = PREV_TS THEN NULL -- Keine Berechnung möglich, wenn kein vorheriger Punkt oder Zeitstempel identisch\n",
+    "        WHEN PREV_TS IS NULL OR TS = PREV_TS THEN NULL -- Keine Berechnung m\u00f6glich, wenn kein vorheriger Punkt oder Zeitstempel identisch\n",
     "        ELSE\n",
     "            (TEMP - PREV_TEMP) / -- Temperaturdifferenz\n",
     "            ( -- Zeitdifferenz als Interval, dann in Minuten umrechnen\n",
@@ -182,7 +182,7 @@
     "FROM\n",
     "    DeviceRankedData\n",
     "WHERE\n",
-    "    PREV_TS IS NOT NULL -- Schliesst den ersten Punkt pro Gerät aus\n",
+    "    PREV_TS IS NOT NULL -- Schliesst den ersten Punkt pro Ger\u00e4t aus\n",
     "ORDER BY\n",
     "    DEVICE, TS\n",
     "\"\"\""
@@ -215,6 +215,41 @@
     "WHERE\n",
     "    TS >= TO_TIMESTAMP('2020-07-14 00:01:00', 'YYYY-MM-DD HH24:MI:SS')\n",
     "    AND TS <= TO_TIMESTAMP('2020-07-19 03:01:00', 'YYYY-MM-DD HH24:MI:SS')\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d57ba6ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "average_humidity_per_device_query_complex = \"\"\"\n",
+    "SELECT device, avg_humidity FROM (\n",
+    "    SELECT\n",
+    "        device,\n",
+    "        AVG(humidity) OVER (PARTITION BY device) AS avg_humidity,\n",
+    "        ROW_NUMBER() OVER (PARTITION BY device ORDER BY device) AS rn\n",
+    "    FROM iot_telemetry_data\n",
+    ")\n",
+    "WHERE rn = 1\n",
+    "ORDER BY device\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ca62385",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "highest_temp_query_complex = \"\"\"\n",
+    "SELECT max_temp FROM (\n",
+    "    SELECT temp, MAX(temp) OVER () AS max_temp\n",
+    "    FROM iot_telemetry_data\n",
+    ") WHERE ROWNUM = 1\n",
     "\"\"\""
    ]
   },
@@ -400,6 +435,52 @@
     "    connection.close()\n",
     "except oracledb.DatabaseError as e:\n",
     "    print(\"Error: \", e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eb48e09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    connection = create_connection()\n",
+    "    cursor = connection.cursor()\n",
+    "    start_time = time.time()\n",
+    "    cursor.execute(average_humidity_per_device_query_complex)\n",
+    "    result = cursor.fetchall()\n",
+    "    end_time = time.time()\n",
+    "    print(f\"Successfull fetched in {end_time - start_time} seconds.\")\n",
+    "    print(result)\n",
+    "    query_times['Average Humidity Complex'] = (end_time - start_time)\n",
+    "    cursor.close()\n",
+    "    connection.close()\n",
+    "except oracledb.DatabaseError as e:\n",
+    "    print(\"Error:\", e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c36486d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    connection = create_connection()\n",
+    "    cursor = connection.cursor()\n",
+    "    start_time = time.time()\n",
+    "    cursor.execute(highest_temp_query_complex)\n",
+    "    result = cursor.fetchall()\n",
+    "    end_time = time.time()\n",
+    "    print(f\"Successfull fetched in {end_time - start_time} seconds.\")\n",
+    "    print(result)\n",
+    "    query_times['Highest Temp Complex'] = (end_time - start_time)\n",
+    "    cursor.close()\n",
+    "    connection.close()\n",
+    "except oracledb.DatabaseError as e:\n",
+    "    print(\"Error:\", e)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add complex query variants in influx analysis
- add complex query variants in oracle analysis
- document complex query variants in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bf2762a0832ca7dfdfc2a7e102f3